### PR TITLE
Cast $state to string before createFromFormat()

### DIFF
--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -83,7 +83,7 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
 
             if (! $state instanceof CarbonInterface) {
                 try {
-                    $state = Carbon::createFromFormat($component->getFormat(), $state, config('app.timezone'));
+                    $state = Carbon::createFromFormat($component->getFormat(), (string) $state, config('app.timezone'));
                 } catch (InvalidFormatException $exception) {
                     try {
                         $state = Carbon::parse($state, config('app.timezone'));


### PR DESCRIPTION
Cast $state to string before createFromFormat()

Fix #11889